### PR TITLE
Check which .mbtiles files are readable

### DIFF
--- a/tileserver.php
+++ b/tileserver.php
@@ -71,13 +71,13 @@ class Server {
     $mjs = glob('*/metadata.json');
     $mbts = glob('*.mbtiles');
     if ($mjs) {
-      foreach ($mjs as $mj) {
+      foreach (array_filter($mjs, 'is_readable') as $mj) {
         $layer = $this->metadataFromMetadataJson($mj);
         array_push($this->fileLayer, $layer);
       }
     }
     if ($mbts) {
-      foreach ($mbts as $mbt) {
+      foreach (array_filter($mbts, 'is_readable') as $mbt) {
         $this->dbLayer[] = $this->metadataFromMbtiles($mbt);
       }
     }


### PR DESCRIPTION
In my setup some .mbtiles are links to an external hard drive - don't fail when the external drive is not connected. (Also this would allow to manage "publishing a map" via unix permission.)
