### PR TITLE
Faster check for grids in large mbtiles file. Closes #51.

### DIFF
--- a/tileserver.php
+++ b/tileserver.php
@@ -545,7 +545,7 @@ class Json extends Server {
     $metadata['tiles'] = $tiles;
     if ($this->isDBLayer($metadata['basename'])) {
       $this->DBconnect($metadata['basename'] . '.mbtiles');
-      $res = $this->db->query('SELECT grid FROM grids LIMIT 1');
+      $res = $this->db->query('SELECT name FROM sqlite_master WHERE name="grids";');
       if ($res) {
         foreach ($this->config['baseUrls'] as $url) {
           $grids[] = '' . $this->config['protocol'] . '://' . $url . '/' . $metadata['basename'] . '/{z}/{x}/{y}.grid.json';


### PR DESCRIPTION
In the ticket #51 was reported that large MBTiles files missing the `grids` view causes the TileServerPHP metadata to load with a delay of up to several minutes.

This PR is makes the check for availability of the `grids` table differently - in a faster way and should fix #51