### PR TITLE
add jpgpng support for ArcGIS Desktop

### DIFF
--- a/tileserver.php
+++ b/tileserver.php
@@ -745,7 +745,11 @@ class Wmts extends Server {
       $profile = $m['profile'];
       $bounds = $m['bounds'];
       $format = $m['format'];
-      $mime = ($format == 'jpg') ? 'image/jpeg' : 'image/png';
+      if ($format == 'jpgpng'){
+        $mime = 'image/jpgpng';
+      } else {
+        $mime = ($format == 'jpg') ? 'image/jpeg' : 'image/png';
+      }  
       if ($profile == 'geodetic') {
         $tileMatrixSet = "WGS84";
       } else {


### PR DESCRIPTION
Arc doesn't like the mixed tiles from the -hybrid switch, it will only draw the ones that match the mime type. We've been running a script to change type:jpg to type:jpgpng. 

jon.sellars