### PR TITLE
Removes trailing query parameters

### DIFF
--- a/tileserver.php
+++ b/tileserver.php
@@ -1240,17 +1240,18 @@ class Router {
 			$xForwarded = true;
 		}
 	}
-	$config['protocol'] = ((isset($_SERVER['HTTPS']) or (isset($_SERVER['SERVER_PORT']) && $_SERVER['SERVER_PORT'] == 443)) or $xForwarded) ? 'https' : 'http';
+  $config['protocol'] = ((isset($_SERVER['HTTPS']) or (isset($_SERVER['SERVER_PORT']) && $_SERVER['SERVER_PORT'] == 443)) or $xForwarded) ? 'https' : 'http';
+  $requestURINoQuery = substr($_SERVER['REQUEST_URI'], 0, strpos( $_SERVER['REQUEST_URI'], '&', strrpos( $_SERVER['REQUEST_URI'], '?')));
     if (!empty($_SERVER['PATH_INFO'])) {
       $path_info = $_SERVER['PATH_INFO'];
     } else if (!empty($_SERVER['ORIG_PATH_INFO']) && strpos($_SERVER['ORIG_PATH_INFO'], 'tileserver.php') === false) {
       $path_info = $_SERVER['ORIG_PATH_INFO'];
     } else if (!empty($_SERVER['REQUEST_URI']) && strpos($_SERVER['REQUEST_URI'], '/tileserver.php') !== false) {
-      $path_info = $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
-      $config['baseUrls'][0] = $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'] . '?';
+      $path_info = $_SERVER['HTTP_HOST'] . $requestURINoQuery;
+      $config['baseUrls'][0] = $_SERVER['HTTP_HOST'] . $requestURINoQuery . '?';
     } else {
       if (!empty($_SERVER['REQUEST_URI'])) {
-        $path_info = (strpos($_SERVER['REQUEST_URI'], '?') > 0) ? strstr($_SERVER['REQUEST_URI'], '?', true) : $_SERVER['REQUEST_URI'];
+        $path_info = (strpos($requestURINoQuery, '?') > 0) ? strstr($requestURINoQuery, '?', true) : $requestURINoQuery;
       }
     }
     $discovered_handler = null;


### PR DESCRIPTION
When tiles are requested with a query parameter (to avoid their caching by the browser for example) tileserver.php answers with an empty image.
This PR removes all the query parameters from the first & to the end of the request URI so it works as expected.

Example:
**Browser request:** _tileserver.php?/normalmap/15/16540/12182.png&20180306135412_
**Request URI used by tileserver:** _tileserver.php?/normalmap/15/16540/12182.png_