### PR TITLE
Removes body data from http 204 response

### DIFF
--- a/tileserver.php
+++ b/tileserver.php
@@ -421,7 +421,6 @@ class Server {
         header('Access-Control-Allow-Origin: *');
         header('HTTP/1.1 204 No Content');
         header('Content-Type: application/json; charset=utf-8');
-        echo '{"message":"Tile does not exist"}';
         break;
       case 'webp':
         header('Access-Control-Allow-Origin: *');


### PR DESCRIPTION
The HTTP 1.1 specification states the following on the [204 No content status code definition](https://tools.ietf.org/html/rfc2616#page-60):

> The 204 response MUST NOT include a message-body, and thus is always
> terminated by the first empty line after the header fields.

Some Vector Tile libraries (at least Mapbox GL Native and Mapbox GL React Native) throw an error if a body message is present on an HTTP response with the 204 status code. This PR removes the body message from the response when an HTTP 204 response is sent.

**Note:** This PR is the same as the one in [tileserver-gl/pull/339](https://github.com/klokantech/tileserver-gl/pull/339) but with the changes done in tileserver.php